### PR TITLE
WIP: DADA2 scripts

### DIFF
--- a/convert_dada2_out.R
+++ b/convert_dada2_out.R
@@ -1,0 +1,130 @@
+#!/usr/bin/env Rscript
+
+# Read in package to read in command-line options.
+suppressMessages(library("optparse"))
+
+version <- "1.0"
+
+option_list <- list(
+  
+  make_option(c("-i", "--input"), type="character", default=NULL,
+              help="Input RDS file of dada2 sequence table (required)." , 
+              metavar="path"),
+  
+  make_option(c("-b", "--biom"), type="character", default="seqtab.biom",
+              help="Path to output BIOM file (required).", 
+              metavar="path"),
+  
+  make_option(c("-f", "--fasta"), type="character", default="seqtab.fasta",
+              help="Path to output FASTA file (required).", 
+              metavar="path"),
+  
+  make_option(c("--taxa_in"), type="character", default=NULL,
+              help="Optional path to RDS containing table of taxa labels for dada2 variants", 
+              metavar="path"),
+  
+  make_option(c("--taxa_out"), type="character", default="taxa_metadata.txt",
+              help="Path for output of taxonomy metadata (default: taxa_metadata.txt).", 
+              metavar="path"),
+  
+  make_option(c("--verbose"), action = "store_true", type="logical", default=FALSE,
+              help="Print out more detailed information.", metavar = "boolean"),
+  
+  make_option(c("--version"), action = "store_true", type="logical", default=FALSE,
+              help="Print out version number and exit.", metavar = "boolean")
+  
+)
+
+opt_parser <- OptionParser(option_list=option_list, 
+                           usage = "%prog [options] -i seqtab.rds -b seqtab.biom -f seqtab.fasta",
+                           
+                           description = paste("Script to convert dada2 sequence table to a BIOM and FASTA file.\n",
+                                               "You can also specify an RDS file containing the taxa labels to create",
+                                               "a BIOM observation metadata table for taxonomy", sep="")
+)
+
+opt <- parse_args(opt_parser)
+
+# Print out version if --version flag set.
+if (opt$version) {
+  cat("Wrapper version:", version, "\n")
+  options_tmp <- options(show.error.messages=FALSE) 
+  on.exit(options(options_tmp)) 
+  stop()
+}
+
+if(is.null(opt$input)) {
+  stop("path to input sequence table RDS needs to be set.")
+}
+
+if(is.null(opt$biom)) {
+  stop("path to output biom table needs to be set.")
+}
+
+if(is.null(opt$fasta)) {
+  stop("path to output fasta file needs to be set.")
+}
+
+# Read in other required packages.
+if(opt$verbose){
+  library("ShortRead")
+  library("biom")
+} else {
+  suppressMessages(library("ShortRead"))
+  suppressMessages(library("biom"))
+}
+
+in_seqtab <- readRDS(opt$input)
+
+seqs <- colnames(in_seqtab)
+ids_study <- paste("seq", 1:ncol(in_seqtab), sep = "_")
+
+colnames(in_seqtab) <- ids_study
+
+if(opt$verbose){
+  cat("\nWriting sequences to", opt$fasta, "\n\n")
+}
+
+# Write out fasta file.
+writeFasta(ShortRead(sread = DNAStringSet(seqs), id = BStringSet(ids_study)), 
+           file = opt$fasta)
+
+if(opt$verbose){
+  cat("Writing output biom table to", opt$biom, "\n\n")
+}
+
+# Write out biom file.
+biom::write_biom(biom::make_biom(data = t(in_seqtab)), 
+                 biom_file = opt$biom)
+
+# If taxa file specified then also read that in.
+if(!is.null(opt$taxa_in)){
+  
+  in_taxa <- readRDS(opt$taxa_in)
+  
+  # Check that dada2 variants are in same order as sequence table.
+  if(!identical(rownames(in_taxa), seqs)){
+    stop("sequences in taxa and sequence table aren't ordered the same.")
+  }
+  
+  rownames(in_taxa) <- ids_study
+  
+  taxa_combined <- apply(in_taxa, 1, function(x) paste(x, collapse=";"))
+  
+  taxa_out <- data.frame(names(taxa_combined), taxa_combined)
+  colnames(taxa_out) <- c("#OTU ID", "taxonomy")
+  
+  if(opt$verbose){
+    cat("Writing taxonomy observation metadata to", opt$taxa_out, "\n\n")
+  }
+  
+  write.table(x = taxa_out, file = opt$taxa_out, quote = FALSE, sep="\t",
+              col.names = TRUE, row.names = FALSE)
+  
+} else {
+  
+  if(opt$verbose){
+    cat("No taxonomy file specified so not making taxonomy observation file.\n")
+  }
+   
+}

--- a/convert_dada2_out.R
+++ b/convert_dada2_out.R
@@ -35,12 +35,13 @@ option_list <- list(
   
 )
 
-opt_parser <- OptionParser(option_list=option_list, 
-                           usage = "%prog [options] -i seqtab.rds -b seqtab.biom -f seqtab.fasta",
-                           
-                           description = paste("Script to convert dada2 sequence table to a BIOM and FASTA file.\n",
-                                               "You can also specify an RDS file containing the taxa labels to create",
-                                               "a BIOM observation metadata table for taxonomy", sep="")
+opt_parser <- OptionParser(
+                   option_list=option_list, 
+                   usage = "%prog [options] -i seqtab_final.rds -b seqtab.biom -f seqtab.fasta",
+                   description = paste(
+                     "Script to convert dada2 sequence table to a BIOM and FASTA file.\n",
+                     "You can also specify an RDS file containing the taxa labels to create",
+                     "a BIOM observation metadata table for taxonomy", sep="")
 )
 
 opt <- parse_args(opt_parser)
@@ -104,10 +105,13 @@ if(!is.null(opt$taxa_in)){
   
   # Check that dada2 variants are in same order as sequence table.
   if(!identical(rownames(in_taxa), seqs)){
-    stop("sequences in taxa and sequence table aren't ordered the same.")
+    stop("sequences in taxa and sequence table are not ordered the same.")
   }
   
   rownames(in_taxa) <- ids_study
+
+  # Replace all NA values with "Unclassified".
+  in_taxa[is.na(in_taxa)] <- "Unclassified"
   
   taxa_combined <- apply(in_taxa, 1, function(x) paste(x, collapse=";"))
   

--- a/dada2_chimera_taxa.R
+++ b/dada2_chimera_taxa.R
@@ -1,0 +1,264 @@
+#!/usr/bin/env Rscript
+
+# Read in package to read in command-line options.
+library("optparse")
+
+version <- "1.0"
+
+option_list <- list(
+
+  make_option(c("-i", "--input"), type="character", default=NULL,
+              help="Location of input .RDS file (required)." , metavar="path"),
+  
+  make_option(c("-r", "--refFasta"), type="character", default=NULL,
+              help="Location of reference fasta to use for taxa assignment (required).", 
+              metavar="path"),
+  
+  make_option(c("-s", "--ref_species"), type="character", default=NULL,
+              help="Location of reference fasta to use for species assignment (required).", 
+              metavar="path"),
+  
+  make_option(c("--seed"), type="integer", default=NULL,
+              help="Random seed to make command reproducible (required).", metavar = "integer"),
+  
+  make_option(c("-t", "--threads"), type="integer", default=1,
+              help="Number of threads to use (default: 1).", metavar="integer"),
+  
+  make_option(c("--skip_species"), action = "store_true", type="logical", default=FALSE,
+              help=paste("Flag to indicate that the species assignment step should be skipped.",
+                         "This step can often be the slowest step. (default: FALSE).", sep=" "),
+              metavar = "boolean"),
+  
+  make_option(c("--count_out"), type="character", default="seqtab_final.rds",
+              help=paste("Output RDS file for sequence table after chimera filtering",
+                         "(default: \"seqtab.rds\").", sep=" "), metavar="path"),
+  
+  make_option(c("--tax_out"), type="character", default="tax_final.rds",
+              help=paste("Output RDS file for sequence table after chimera filtering",
+                         "(default: \"tax_final.rds\").", sep=" "), metavar="path"),
+  
+  make_option(c("--chimera_method"), type="character", default="consensus",
+              help=paste("Method for chimera checking, one of \"consensus\", \"pooled\",",
+                         "or \"per-sample\". See dada2 manual for details.",
+                         "(default: \"consensus\").", sep=" ")),
+  
+  make_option(c("--minFoldParentOverAbundance"), type="numeric", default=1,
+              help=paste("Sequences with this fold-abundance greater than a given sequence", 
+                         "can be considered as \"parents\" (default: 1)", sep=" "), 
+              metavar="numeric"),
+  
+  make_option(c("--minParentAbundance"), type="numeric", default=8,
+              help=paste("Sequences with this abundance", 
+                         "can be considered as \"parents\" (default: 8)", sep=" "), 
+              metavar="numeric"),
+  
+  make_option(c("--allowOneOff"), action = "store_true", type="logical", default=TRUE,
+              help=paste("Flag to indicate that sequences with one mismatch or indel",
+                         "to an exact bimera are also taken to be bimeras (default: TRUE).", sep=" "),
+              metavar = "boolean"),
+  
+  make_option(c("--minOneOffParentDistance"), type="numeric", default=4,
+              help=paste("When flagging one-off bimeras only sequences with at least this many", 
+                         "many mismatches to potential bimera are considered \"parents\" (default: 4)", 
+                         sep=" ")), 
+              
+ make_option(c("--maxShift"), type="numeric", default=16,
+             help=paste("Max shift allowed when aligning sequences to potential \"parents\"", 
+                        "(default: 16)", sep=" ")), 
+
+ make_option(c("--minSampleFraction"), type="numeric", default=0.9,
+             help=paste("Fraction of samples in which a sequence must be flagged as a bimera", 
+                        "to be classified as a bimera (default: 0.9)", sep=" ")),               
+ 
+ make_option(c("--ignoreNNegatives"), type="integer", default=1,
+             help=paste("Number of unflagged samples to ignore when evaluating whether", 
+                        "sequence was flagged in bimera in more than minSampleFraction",
+                        "samples (default: 1)", sep=" ")), 
+ 
+ make_option(c("--minBoot"), type="numeric", default=50,
+             help=paste("Min bootstrap confidence for assigning taxa label", 
+                        "(default: 50)", sep=" ")), 
+ 
+ make_option(c("--tryRC"), action = "store_true", type="logical", default=FALSE,
+             help=paste("Flag to indicate that the reverse-complement of sequences",
+                        "should be used for taxa assignment if it is a better match",
+                        "to the reference database (default: FALSE).", sep=" "),
+             metavar = "boolean"),
+ 
+ make_option(c("--allowMultiple"), action = "store_true", type="logical", default=FALSE,
+             help=paste("Flag to indicate that if multiple different species are exact",
+                        "matches then these should all be returned (default: FALSE).", sep=" "),
+             metavar = "boolean"),
+ 
+  make_option(c("--log"), type="character", default="dada2_nonchimera_counts.txt",
+              help="Output logfile for read count table (default: dada2_nonchimera_counts.txt).", 
+              metavar="path"),
+  
+  make_option(c("--verbose"), action = "store_true", type="logical", default=FALSE,
+              help="Write out status messages (default: FALSE).", metavar = "boolean"),
+  
+  make_option(c("--version"), action = "store_true", type="logical", default=FALSE,
+              help="Print out version number and exit.", metavar = "boolean")
+
+)
+
+opt_parser <- OptionParser(option_list=option_list, 
+                           usage = "%prog [options] -i seqtab.rds -r /path/to/ref.fa -s /path/to/species_ref.fa --seed 123",
+                           
+                           description = paste("\nThis is a wrapper for the DADA2 chimera and tax assignment step that is", 
+                                               "based on the authors\' big data tutorial available here:",
+                                               "https://benjjneb.github.io/dada2/bigdata.html.\n\nBe sure to cite the DADA2",
+                                               "paper if you use this script:\nCallahan BJ et al. 2016. DADA2:",
+                                               "High-resolution sample inference from Illumina amplicon data.",
+                                               "Nature Methods 13:581-583.\n\nNote this script was tested with",
+                                               "DADA2 v1.4.0", sep=" ")
+                          )
+
+opt <- parse_args(opt_parser)
+
+# Print out version if --version flag set.
+if (opt$version) {
+  cat("Wrapper version:", version, "\n")
+  options_tmp <- options(show.error.messages=FALSE) 
+  on.exit(options(options_tmp)) 
+  stop()
+}
+
+# Check if path to input RDS set, if not stop job.
+if(is.null(opt$input)) {
+  stop("path to input RDS needs to be set.")
+}
+
+# Check that refFasta set.
+if(is.null(opt$refFasta)) {
+  stop("Path to refFasta needs to be set.")
+}
+
+# Check that ref_species set if doing species assignment.
+if(!opt$skip_species & is.null(opt$refFasta)) {
+  stop("Path to refFasta needs to be set.")
+}
+
+# Check that random seed set.
+if(is.null(opt$seed)) {
+  stop("random seed needs to be set.")
+}
+
+# Check that chimera method is one of 3 possible choices.
+if(! opt$chimera_method %in% c("consensus", "pooled", "per-sample")) {
+ stop(paste("--chimera_method needs to be one of \"consensus\",",
+            "\"pooled\", or \"per-sample\"", sep=" "))
+}
+
+# Set multithread option (FALSE if no, otherwise give # core).
+if (opt$threads > 1) {
+  multithread_opt <- opt$threads
+} else {
+  multithread_opt <- FALSE
+}
+
+# Load in input RDS file.
+in_seqtab <- readRDS(opt$input)
+
+# Read in and print out DADA2 version.
+library("dada2")
+
+if(opt$verbose) {
+        cat("Running DADA2 version:", as.character(packageVersion("dada2")), "\n\n",
+        "Running removeBimeraDenovo with below options.\n",
+        "method =", opt$chimera_method, "\n",
+        "minFoldParentOverAbundance =", opt$minFoldParentOverAbundance, "\n",
+        "minParentAbundance =", opt$minParentAbundance, "\n",
+        "allowOneOff =", opt$allowOneOff, "\n",
+        "minOneOffParentDistance =", opt$minOneOffParentDistance, "\n",
+        "maxShift =", opt$maxShift, "\n",
+        "minSampleFraction =", opt$minSampleFraction, "\n",
+        "ignoreNNegatives =", opt$ignoreNNegatives, "\n\n")
+}
+
+seqtab_nochim <- removeBimeraDenovo(in_seqtab, 
+                                    method=opt$chimera_method, 
+                                    minFoldParentOverAbundance=opt$minFoldParentOverAbundance,
+                                    minParentAbundance=opt$minParentAbundance,
+                                    allowOneOff=opt$allowOneOff,
+                                    minOneOffParentDistance=opt$minOneOffParentDistance,
+                                    maxShift=opt$maxShift,
+                                    minSampleFraction=opt$minSampleFraction,
+                                    ignoreNNegatives=opt$ignoreNNegatives,
+                                    multithread=multithread_opt,
+                                    verbose=opt$verbose)
+
+if(opt$verbose) {
+  cat("Running assignTaxonomy with below options.\n",
+      "Random seed:", as.character(opt$seed), "\n\n",
+      "refFasta =", opt$refFasta, "\n",
+      "minBoot =", opt$minBoot, "\n",
+      "tryRC =", opt$tryRC, "\n\n")
+}
+
+# Set random seed for reproducibility.
+set.seed(opt$seed)
+
+# Run taxonomy assignment.
+taxa <- assignTaxonomy(seqs=seqtab_nochim, 
+                       refFasta=opt$refFasta,
+                       minBoot=opt$minBoot,
+                       tryRC=opt$tryRC,
+                       multithread=multithread_opt,
+                       verbose=opt$verbose)
+
+if(! opt$skip_species) {
+
+  if(opt$verbose) {
+    cat("\n\nRunning addSpecies with below options.\n",
+        "refFasta =", opt$ref_species, "\n",
+        "allowMultiple =", opt$allowMultiple, "\n\n")
+  }
+  
+  # Add exact species assignment where possible.
+  taxa_species <- addSpecies(taxtab=taxa, 
+                             refFasta=opt$ref_species, 
+                             allowMultiple = opt$allowMultiple, 
+                             verbose = opt$verbose)
+  
+  # Write out taxa + species table.
+  saveRDS(taxa_species, opt$tax_out)
+  
+} else {
+  
+  if(opt$verbose) {
+    cat("\n\nSkipping addSpecies step.\n\n")
+  }
+ 
+  # Write out the taxa count table without species.
+  saveRDS(taxa, opt$tax_out)
+  
+}
+
+# Write out count table as RDS.
+saveRDS(seqtab_nochim, opt$count_out)
+
+
+# Track read and variants counts before and after chimera checking.
+
+log_counts <- as.data.frame(
+               cbind(rowSums(in_seqtab),
+               rowSums(seqtab_nochim),
+               rowSums(in_seqtab != 0),
+               rowSums(seqtab_nochim != 0)))
+
+saveRDS(in_seqtab,file = "tmp1.rds")
+saveRDS(seqtab_nochim,file = "tmp2.rds")
+saveRDS(in_seqtab,file = "tmp3.rds")
+saveRDS(seqtab_nochim,file = "tmp4.rds")
+
+colnames(log_counts) <- c("input_reads", "nonchimera_reads",
+                          "input_variants", "nonchimera_variants")
+
+log_counts$sample <- rownames(in_seqtab)
+
+log_counts <- log_counts[,c("sample", "input_reads", "nonchimera_reads",
+                            "input_variants", "nonchimera_variants")]
+
+write.table(x = log_counts, file = opt$log, quote = FALSE, sep="\t",
+            col.names = TRUE, row.names = FALSE)

--- a/dada2_filter.R
+++ b/dada2_filter.R
@@ -3,6 +3,8 @@
 # Read in package to read in command-line options.
 library("optparse")
 
+# Source Rscript containing functions 
+
 version <- "1.0"
 
 option_list <- list(
@@ -18,7 +20,7 @@ option_list <- list(
               help="Flag to indicate that reads are single-end (default: FALSE).", metavar = "boolean"),
   
   make_option(c("--f_match"), type="character", default="_R1_.*fastq.*",
-              help="Regular expression to match in forward reads' filenames (default: _R1_.*fastq.*).", 
+              help="Regular expression to match in forward reads' filenames (default: \"_R1_.*fastq.*\").", 
               metavar="PATTERN"),
   
   make_option(c("--r_match"), type="character", default="_R2_.*fastq.*",
@@ -109,7 +111,7 @@ opt_parser <- OptionParser(option_list=option_list,
                            usage = "%prog [options] -f PATH",
                            
                            description = paste("\nThis is a wrapper for DADA2 that is based on the authors\'", 
-                                               "big data tutorial available here:",
+                                               "filtering step in the big data tutorial available here:",
                                                "https://benjjneb.github.io/dada2/bigdata.html.\n\nBe sure to cite the DADA2",
                                                "paper if you use this script:\nCallahan BJ et al. 2016. DADA2:",
                                                "High-resolution sample inference from Illumina amplicon data.",
@@ -123,6 +125,8 @@ opt_parser <- OptionParser(option_list=option_list,
 opt <- parse_args(opt_parser)
 
 # Function to parse DADA2 filtering params and to throw error if any unexpected input.
+# This function deals with cases where multiple options are specified for forward
+# and reverse reads at the filtering step.
 parse_dada2_filt_params <- function(in_param, single_end, param_name) {
   
   # Split by comma (in case separate options given for R1 and R2).
@@ -136,11 +140,11 @@ parse_dada2_filt_params <- function(in_param, single_end, param_name) {
   
   # Make sure that only one value given if SE.
   if(single_end & length(in_param_split) != 1) {
-        stop(paste("Error when parsing parameter", param_name, "-",
-                   "expected 1 input value, but got", length(in_param_split), 
-                   sep=" "))
-             
-  # Make sure that max of 2 values given if PE.
+    stop(paste("Error when parsing parameter", param_name, "-",
+               "expected 1 input value, but got", length(in_param_split), 
+               sep=" "))
+    
+    # Make sure that max of 2 values given if PE.
   } else if(! single_end & length(in_param_split) > 2) {
     stop(paste("Error when parsing parameter", param_name, "-",
                "expected max of 2 input values, but got", length(in_param_split), 
@@ -152,7 +156,6 @@ parse_dada2_filt_params <- function(in_param, single_end, param_name) {
   } else {
     return(c(as.numeric(in_param_split[1]), as.numeric(in_param_split[2])))
   }
-  
 }
 
 # Print out version if --version flag set.
@@ -210,21 +213,21 @@ if (opt$single) {
   if(opt$verbose) {
     
     cat("Single-end mode\n\n")
-    cat(paste("fwd=", paste(forward_in, collapse=",") , "\n", 
-              "filt=", paste(forward_out, collapse=","), "\n",
-              "compress=", !opt$no_gzip, "\n",
-              "truncQ=", paste(filt_params$truncQ, collapse=","), "\n",  
-              "truncLen=", paste(filt_params$truncLen, collapse=","), "\n", 
-              "trimLef=", paste(filt_params$trimLeft, collapse=","), "\n",  
-              "maxLen=", paste(filt_params$maxLen, collapse=","), "\n", 
-              "minLen=", paste(filt_params$minLen, collapse=","), "\n",  
-              "maxN=", paste(filt_params$maxN, collapse=","), "\n", 
-              "minQ=", paste(filt_params$minQ, collapse=","), "\n",
-              "maxEE=", paste(filt_params$maxEE, collapse=","), "\n",
-              "rm.phix=", !opt$no_rm_phiX, "\n",
-              "multithread=", multithread_opt, "\n",
-              "n=", opt$num_reads, "\n",
-              "verbose=", opt$verbose, "\n\n", sep=""))
+    cat(paste("fwd =", paste(forward_in, collapse=",") , "\n", 
+              "filt =", paste(forward_out, collapse=","), "\n",
+              "compress =", !opt$no_gzip, "\n",
+              "truncQ =", paste(filt_params$truncQ, collapse=","), "\n",  
+              "truncLen =", paste(filt_params$truncLen, collapse=","), "\n", 
+              "trimLef =", paste(filt_params$trimLeft, collapse=","), "\n",  
+              "maxLen =", paste(filt_params$maxLen, collapse=","), "\n", 
+              "minLen =", paste(filt_params$minLen, collapse=","), "\n",  
+              "maxN =", paste(filt_params$maxN, collapse=","), "\n", 
+              "minQ =", paste(filt_params$minQ, collapse=","), "\n",
+              "maxEE =", paste(filt_params$maxEE, collapse=","), "\n",
+              "rm.phix =", !opt$no_rm_phiX, "\n",
+              "multithread =", multithread_opt, "\n",
+              "n =", opt$num_reads, "\n",
+              "verbose =", opt$verbose, "\n\n", sep=""))
   }
   
   read_counts <- filterAndTrim(fwd=forward_in, filt=forward_out, compress=!opt$no_gzip,
@@ -255,26 +258,26 @@ if (opt$single) {
   
   if(opt$verbose) {
     cat("Paired-end mode\n")
-    cat(paste("fwd=", paste(forward_in, collapse=",") , "\n", 
-              "filt=", paste(forward_out, collapse=","), "\n",
-              "rev=", paste(reverse_in, collapse=","), "\n",
-              "filt.rev=", paste(reverse_out, collapse=","), "\n",
-              "compress=", !opt$no_gzip, "\n",
-              "truncQ=", paste(filt_params$truncQ, collapse=","), "\n",  
-              "truncLen=", paste(filt_params$truncLen, collapse=","), "\n", 
-              "trimLef=", paste(filt_params$trimLeft, collapse=","), "\n",  
-              "maxLen=", paste(filt_params$maxLen, collapse=","), "\n", 
-              "minLen=", paste(filt_params$minLen, collapse=","), "\n",  
-              "maxN=", paste(filt_params$maxN, collapse=","), "\n", 
-              "minQ=", paste(filt_params$minQ, collapse=","), "\n",
-              "maxEE=", paste(filt_params$maxEE, collapse=","), "\n",
-              "rm.phix=", !opt$no_rm_phiX, "\n",
-              "multithread=", multithread_opt, "\n",
-              "n=", opt$num_reads, "\n",
-              "matchIDs=", opt$matchIDs, "\n", 
-              "id.sep=", opt$id_sep, "\n",
-              "id.field=", id_field_log, "\n", 
-              "verbose=", opt$verbose, "\n\n", sep=""))
+    cat(paste("fwd =", paste(forward_in, collapse=",") , "\n", 
+              "filt =", paste(forward_out, collapse=","), "\n",
+              "rev =", paste(reverse_in, collapse=","), "\n",
+              "filt.rev =", paste(reverse_out, collapse=","), "\n",
+              "compress =", !opt$no_gzip, "\n",
+              "truncQ =", paste(filt_params$truncQ, collapse=","), "\n",  
+              "truncLen =", paste(filt_params$truncLen, collapse=","), "\n", 
+              "trimLef =", paste(filt_params$trimLeft, collapse=","), "\n",  
+              "maxLen =", paste(filt_params$maxLen, collapse=","), "\n", 
+              "minLen =", paste(filt_params$minLen, collapse=","), "\n",  
+              "maxN =", paste(filt_params$maxN, collapse=","), "\n", 
+              "minQ =", paste(filt_params$minQ, collapse=","), "\n",
+              "maxEE =", paste(filt_params$maxEE, collapse=","), "\n",
+              "rm.phix =", !opt$no_rm_phiX, "\n",
+              "multithread =", multithread_opt, "\n",
+              "n =", opt$num_reads, "\n",
+              "matchIDs =", opt$matchIDs, "\n", 
+              "id.sep =", opt$id_sep, "\n",
+              "id.field =", id_field_log, "\n", 
+              "verbose =", opt$verbose, "\n\n", sep=""))
   }
   
   read_counts <- filterAndTrim(fwd=forward_in, filt=forward_out, rev=reverse_in,

--- a/dada2_filter.R
+++ b/dada2_filter.R
@@ -1,16 +1,14 @@
 #!/usr/bin/env Rscript
 
 # Read in package to read in command-line options.
-library("optparse")
-
-# Source Rscript containing functions 
+suppressMessages(library("optparse"))
 
 version <- "1.0"
 
 option_list <- list(
 
   make_option(c("-f", "--f_path"), type="character", default=NULL,
-              help="Location of forward reads (required)." , metavar="path"),
+              help="Location of forward reads (required).", metavar="path"),
   
   make_option(c("-r", "--r_path"), type="character", default=NULL,
               help="Location of reverse reads (if applicable). Same as forward reads by default.",
@@ -29,7 +27,7 @@ option_list <- list(
   
   make_option(c("--sample_delim"), type="character", default="_",
               help=paste("Character to split filenames on to determine sample name (default: \"_\").",
-              "Sample names are assumed to be field 1 after splitting.", sep=" "),
+              "Sample names are assumed to be 1st field after splitting.", sep=" "),
               metavar="PATTERN"),
   
   make_option(c("--truncQ"), type="character", default="2",
@@ -194,11 +192,12 @@ if (opt$threads > 1) {
 }
 
 # Finally read in and print out DADA2 version.
-library("dada2")
-
 if(opt$verbose) {
   cat("Running DADA2 version:", as.character(packageVersion("dada2")), "\n")
+  library("dada2")
   cat("Running filterAndTrim function with the below options.\n")
+} else {
+  suppressMessages(library("dada2"))
 }
 
 # Set id_field output log to be character of "NULL" so that it is printed (if applicable).
@@ -218,7 +217,7 @@ if (opt$single) {
               "compress =", !opt$no_gzip, "\n",
               "truncQ =", paste(filt_params$truncQ, collapse=","), "\n",  
               "truncLen =", paste(filt_params$truncLen, collapse=","), "\n", 
-              "trimLef =", paste(filt_params$trimLeft, collapse=","), "\n",  
+              "trimLeft =", paste(filt_params$trimLeft, collapse=","), "\n",  
               "maxLen =", paste(filt_params$maxLen, collapse=","), "\n", 
               "minLen =", paste(filt_params$minLen, collapse=","), "\n",  
               "maxN =", paste(filt_params$maxN, collapse=","), "\n", 
@@ -265,7 +264,7 @@ if (opt$single) {
               "compress =", !opt$no_gzip, "\n",
               "truncQ =", paste(filt_params$truncQ, collapse=","), "\n",  
               "truncLen =", paste(filt_params$truncLen, collapse=","), "\n", 
-              "trimLef =", paste(filt_params$trimLeft, collapse=","), "\n",  
+              "trimLeft =", paste(filt_params$trimLeft, collapse=","), "\n",  
               "maxLen =", paste(filt_params$maxLen, collapse=","), "\n", 
               "minLen =", paste(filt_params$minLen, collapse=","), "\n",  
               "maxN =", paste(filt_params$maxN, collapse=","), "\n", 

--- a/dada2_filter.R
+++ b/dada2_filter.R
@@ -155,8 +155,6 @@ parse_dada2_filt_params <- function(in_param, single_end, param_name) {
   
 }
 
-
-
 # Print out version if --version flag set.
 if (opt$version) {
   cat("Wrapper version:", version, "\n")
@@ -170,7 +168,7 @@ if(is.null(opt$f_path)) {
   stop("path to forward FASTQs needs to be set.")
 }
 
-# Get forward and reverse filenames.
+# Get forward filenames.
 forward_in <- sort(list.files(opt$f_path, pattern=opt$f_match, full.names=TRUE))
 forward_samples <- sapply(strsplit(basename(forward_in), opt$sample_delim), `[`, 1)
 forward_out <- file.path(opt$output, paste0(forward_samples, "_R1_filt.fastq.gz"))
@@ -275,7 +273,7 @@ if (opt$single) {
               "n=", opt$num_reads, "\n",
               "matchIDs=", opt$matchIDs, "\n", 
               "id.sep=", opt$id_sep, "\n",
-              "id.field=", opt$id_field, "\n", 
+              "id.field=", id_field_log, "\n", 
               "verbose=", opt$verbose, "\n\n", sep=""))
   }
   

--- a/dada2_filter.R
+++ b/dada2_filter.R
@@ -150,7 +150,7 @@ parse_dada2_filt_params <- function(in_param, single_end, param_name) {
   if (length(in_param_split) == 1) {
     return(as.numeric(in_param_split[1]))
   } else {
-    return(as.numeric(in_param_split[1]), as.numeric(in_param_split[2]))
+    return(c(as.numeric(in_param_split[1]), as.numeric(in_param_split[2])))
   }
   
 }
@@ -202,7 +202,7 @@ if(opt$verbose) {
 
 # Set id_field output log to be character of "NULL" so that it is printed (if applicable).
 id_field_log <- opt$id_field
-if(is.null(opt$id_field)) {
+if(is.null(id_field_log)) {
   id_field_log <- "NULL"
 }
 
@@ -215,14 +215,14 @@ if (opt$single) {
     cat(paste("fwd=", paste(forward_in, collapse=",") , "\n", 
               "filt=", paste(forward_out, collapse=","), "\n",
               "compress=", !opt$no_gzip, "\n",
-              "truncQ=", filt_params$truncQ, "\n",  
-              "truncLen=", filt_params$truncLen, "\n", 
-              "trimLef=", filt_params$trimLeft, "\n",  
-              "maxLen=", filt_params$maxLen, "\n", 
-              "minLen=", filt_params$minLen, "\n",  
-              "maxN=", filt_params$maxN, "\n", 
-              "minQ=", filt_params$minQ, "\n",
-              "maxEE=", filt_params$maxEE, "\n",
+              "truncQ=", paste(filt_params$truncQ, collapse=","), "\n",  
+              "truncLen=", paste(filt_params$truncLen, collapse=","), "\n", 
+              "trimLef=", paste(filt_params$trimLeft, collapse=","), "\n",  
+              "maxLen=", paste(filt_params$maxLen, collapse=","), "\n", 
+              "minLen=", paste(filt_params$minLen, collapse=","), "\n",  
+              "maxN=", paste(filt_params$maxN, collapse=","), "\n", 
+              "minQ=", paste(filt_params$minQ, collapse=","), "\n",
+              "maxEE=", paste(filt_params$maxEE, collapse=","), "\n",
               "rm.phix=", !opt$no_rm_phiX, "\n",
               "multithread=", multithread_opt, "\n",
               "n=", opt$num_reads, "\n",
@@ -250,9 +250,9 @@ if (opt$single) {
   
   # Check that sample names for forward and reverse FASTQs are the same.
   if(! identical(forward_samples, reverse_samples)){
-    stop(paste("Sample names parsed from forward and reverse filenames don't match.",
-               "\n\nForward sample names:", forward_samples,
-               "\n\nReverse sample names:", reverse_samples))
+    stop(paste("\n\nSample names parsed from forward and reverse filenames don't match.",
+               "\nForward sample name:", forward_samples,
+               "\nReverse sample name:", reverse_samples))
   }
   
   if(opt$verbose) {
@@ -262,14 +262,14 @@ if (opt$single) {
               "rev=", paste(reverse_in, collapse=","), "\n",
               "filt.rev=", paste(reverse_out, collapse=","), "\n",
               "compress=", !opt$no_gzip, "\n",
-              "truncQ=", filt_params$truncQ, "\n",  
-              "truncLen=", filt_params$truncLen, "\n", 
-              "trimLef=", filt_params$trimLeft, "\n",  
-              "maxLen=", filt_params$maxLen, "\n", 
-              "minLen=", filt_params$minLen, "\n",  
-              "maxN=", filt_params$maxN, "\n", 
-              "minQ=", filt_params$minQ, "\n",
-              "maxEE=", filt_params$maxEE, "\n",
+              "truncQ=", paste(filt_params$truncQ, collapse=","), "\n",  
+              "truncLen=", paste(filt_params$truncLen, collapse=","), "\n", 
+              "trimLef=", paste(filt_params$trimLeft, collapse=","), "\n",  
+              "maxLen=", paste(filt_params$maxLen, collapse=","), "\n", 
+              "minLen=", paste(filt_params$minLen, collapse=","), "\n",  
+              "maxN=", paste(filt_params$maxN, collapse=","), "\n", 
+              "minQ=", paste(filt_params$minQ, collapse=","), "\n",
+              "maxEE=", paste(filt_params$maxEE, collapse=","), "\n",
               "rm.phix=", !opt$no_rm_phiX, "\n",
               "multithread=", multithread_opt, "\n",
               "n=", opt$num_reads, "\n",
@@ -293,9 +293,10 @@ if (opt$single) {
 
 # Convert log table rownames from R1 FASTQs to sample names.
 read_counts <- as.data.frame(read_counts)
-rownames(read_counts) <- sapply(strsplit(rownames(read_counts), opt$sample_delim), `[`, 1)
-colnames(read_counts) <- c("input", "filtered")
+read_counts$sample <- sapply(strsplit(rownames(read_counts), opt$sample_delim), `[`, 1)
+colnames(read_counts) <- c("input", "filtered", "sample")
+read_counts <- read_counts[c("sample", "input", "filtered")]
 
 # Print out input and output read counts to logfile.
 write.table(x = read_counts, file = opt$log, quote = FALSE, sep="\t",
-            col.names = NA, row.names = TRUE)
+            col.names = TRUE, row.names = FALSE)

--- a/dada2_filter.R
+++ b/dada2_filter.R
@@ -1,0 +1,301 @@
+#!/usr/bin/env Rscript
+
+# Read in package to read in command-line options.
+library("optparse")
+
+version <- "1.0"
+
+option_list <- list(
+
+  make_option(c("-f", "--f_path"), type="character", default=NULL,
+              help="Location of forward reads (required)." , metavar="path"),
+  
+  make_option(c("-r", "--r_path"), type="character", default=NULL,
+              help="Location of reverse reads (if applicable). Same as forward reads by default.",
+              metavar="path"),
+  
+  make_option(c("-s", "--single"), action = "store_true", type="logical", default=FALSE,
+              help="Flag to indicate that reads are single-end (default: FALSE).", metavar = "boolean"),
+  
+  make_option(c("--f_match"), type="character", default="_R1_.*fastq.*",
+              help="Regular expression to match in forward reads' filenames (default: _R1_.*fastq.*).", 
+              metavar="PATTERN"),
+  
+  make_option(c("--r_match"), type="character", default="_R2_.*fastq.*",
+              help="Regular expression to match in reverse reads' filenames (default: \"_R2_.*fastq.*\").",
+              metavar="PATTERN"),
+  
+  make_option(c("--sample_delim"), type="character", default="_",
+              help=paste("Character to split filenames on to determine sample name (default: \"_\").",
+              "Sample names are assumed to be field 1 after splitting.", sep=" "),
+              metavar="PATTERN"),
+  
+  make_option(c("--truncQ"), type="character", default="2",
+              help="Reads will be truncated at the first instance of Q <= truncQ (default: 2).", 
+              metavar="numeric,numeric"),
+  
+  make_option(c("--truncLen"), type="character", default="0",
+              help="Length at which to truncate reads - shorter reads will be discarded (default: 0).", 
+              metavar="numeric,numeric"),
+  
+  make_option(c("--trimLeft"), type="character", default="0",
+              help="Number of nucleotides to trim from start of reads (default: 0).", 
+              metavar="numeric,numeric"),
+  
+  make_option(c("--maxLen"), type="character", default="Inf",
+              help="Maximum read length BEFORE trimming and truncation (default: Inf).", 
+              metavar="numeric,numeric"),
+  
+  make_option(c("--minLen"), type="character", default="20",
+              help="Minimum read length AFTER trimming and truncation (default: 20).", 
+              metavar="numeric,numeric"),
+  
+  make_option(c("--maxN"), type="character", default="0",
+              help="Maximum number of Ns after truncation - should be 0 for use with DADA2 (default: 0).", 
+              metavar="numeric,numeric"),
+
+  make_option(c("--minQ"), type="character", default="0",
+              help="Minimum quality score allowed in read after truncation (default: 0).", 
+              metavar="numeric,numeric"),
+  
+  make_option(c("--maxEE"), type="character", default="Inf",
+              help="Maximum expected errors allowed in a read after truncation (default: Inf). EE = sum(10^(-Q/10)).", 
+              metavar="numeric,numeric"),  
+  
+  make_option(c("-t", "--threads"), type="integer", default=1,
+              help="Number of threads to use (default: 1).", metavar="integer"),
+  
+  make_option(c("-n", "--num_reads"), type="integer", default=1e5,
+              help="Number of reads to read into memory at once (default: 1e5).", metavar="integer"),  
+  
+  make_option(c("-o", "--output"), type="character", default="filtered_fastqs",
+              help="Output folder for filtered reads (default: filtered_fastqs).", metavar="path"),
+  
+  make_option(c("--log"), type="character", default="dada2_filter_read_counts.txt",
+              help="Output logfile for read count table (default: dada2_filter_read_counts.txt).", metavar="path"),
+  
+  make_option(c("--no_rm_phiX"), action = "store_true", type="logical", default=FALSE,
+              help="Flag to indicate that reads matching PhiX genome should NOT be discarded (default: FALSE).", 
+              metavar = "boolean"),
+  
+  make_option(c("--no_gzip"), action = "store_true", type="logical", default=FALSE,
+              help="Flag to indicate that output FASTQs should NOT be gzipped (default: FALSE).", 
+              metavar = "boolean"),
+  
+  make_option(c("--matchIDs"), action = "store_true", type="logical", default=FALSE,
+              help=paste("Flag to indicate that paired-end reads that don't share ids",
+                         "in both the forward and reverse FASTQs will be excluded (default: FALSE)", sep=" "), 
+              metavar = "boolean"),
+  
+  make_option(c("--id_sep"), type="character", default="\\s",
+              help="The separator between fields in the id line for paired-end FASTQs (default: \"\\s\").", 
+              metavar = "character"),
+  
+  make_option(c("--id_field"), type="character", default=NULL,
+              help=paste("Field of the FASTQ id line containing sequenced id. By default",
+                         "this will be automatically detected, which will work for most users.",
+                         "Only for paired-end data.", sep=" "), 
+              metavar = "boolean"),
+  
+  make_option(c("--verbose"), action = "store_true", type="logical", default=FALSE,
+              help="Write out status messages (default: FALSE).", metavar = "boolean"),
+  
+  make_option(c("--version"), action = "store_true", type="logical", default=FALSE,
+              help="Print out version number and exit.", metavar = "boolean")
+
+)
+
+opt_parser <- OptionParser(option_list=option_list, 
+                           usage = "%prog [options] -f PATH",
+                           
+                           description = paste("\nThis is a wrapper for DADA2 that is based on the authors\'", 
+                                               "big data tutorial available here:",
+                                               "https://benjjneb.github.io/dada2/bigdata.html.\n\nBe sure to cite the DADA2",
+                                               "paper if you use this script:\nCallahan BJ et al. 2016. DADA2:",
+                                               "High-resolution sample inference from Illumina amplicon data.",
+                                               "Nature Methods 13:581-583.\n\nNote this script was tested with",
+                                               "DADA2 v1.4.0\n\nUSAGE NOTE: when passing filtering parameters for paired-end", 
+                                               "reads if you pass one value it will be used for both forward and reverse reads.",
+                                               "\nIf you pass two values separated by a comma then these values will be for the forward",
+                                               "and reverse reads respectively.", sep=" ")
+                          )
+
+opt <- parse_args(opt_parser)
+
+# Function to parse DADA2 filtering params and to throw error if any unexpected input.
+parse_dada2_filt_params <- function(in_param, single_end, param_name) {
+  
+  # Split by comma (in case separate options given for R1 and R2).
+  in_param_split <- as.vector(strsplit(in_param, ",")[[1]])
+  
+  # Report error if empty string.
+  if(length(in_param_split) == 0) {
+    stop(paste("Error when parsing parameter", param_name, "-",
+               "no values detected.", sep=" "))
+  }
+  
+  # Make sure that only one value given if SE.
+  if(single_end & length(in_param_split) != 1) {
+        stop(paste("Error when parsing parameter", param_name, "-",
+                   "expected 1 input value, but got", length(in_param_split), 
+                   sep=" "))
+             
+  # Make sure that max of 2 values given if PE.
+  } else if(! single_end & length(in_param_split) > 2) {
+    stop(paste("Error when parsing parameter", param_name, "-",
+               "expected max of 2 input values, but got", length(in_param_split), 
+               sep=" "))
+  }
+  
+  if (length(in_param_split) == 1) {
+    return(as.numeric(in_param_split[1]))
+  } else {
+    return(as.numeric(in_param_split[1]), as.numeric(in_param_split[2]))
+  }
+  
+}
+
+
+
+# Print out version if --version flag set.
+if (opt$version) {
+  cat("Wrapper version:", version, "\n")
+  options_tmp <- options(show.error.messages=FALSE) 
+  on.exit(options(options_tmp)) 
+  stop()
+}
+
+# Check if path to forward files set, if not stop job.
+if(is.null(opt$f_path)) {
+  stop("path to forward FASTQs needs to be set.")
+}
+
+# Get forward and reverse filenames.
+forward_in <- sort(list.files(opt$f_path, pattern=opt$f_match, full.names=TRUE))
+forward_samples <- sapply(strsplit(basename(forward_in), opt$sample_delim), `[`, 1)
+forward_out <- file.path(opt$output, paste0(forward_samples, "_R1_filt.fastq.gz"))
+
+# Convert input filtering params to vectors and check for obvious input errors.
+filt_params_raw <- opt[c("truncQ", "truncLen", "trimLeft", "maxLen",
+                         "minLen", "maxN", "minQ", "maxEE")]
+filt_params <- list(c())
+for (param in names(filt_params_raw)) {
+  filt_params[[param]] <- parse_dada2_filt_params(in_param=filt_params_raw[[param]],
+                                                  single_end=opt$single,
+                                                  param_name=param)
+}
+
+# Set multithread option (FALSE if no, otherwise give # core).
+if (opt$threads > 1) {
+  multithread_opt <- opt$threads
+} else {
+  multithread_opt <- FALSE
+}
+
+# Finally read in and print out DADA2 version.
+library("dada2")
+
+if(opt$verbose) {
+  cat("Running DADA2 version:", as.character(packageVersion("dada2")), "\n")
+  cat("Running filterAndTrim function with the below options.\n")
+}
+
+# Set id_field output log to be character of "NULL" so that it is printed (if applicable).
+id_field_log <- opt$id_field
+if(is.null(opt$id_field)) {
+  id_field_log <- "NULL"
+}
+
+# Run DADA2 on just forward reads in single-end data.
+if (opt$single) {
+   
+  if(opt$verbose) {
+    
+    cat("Single-end mode\n\n")
+    cat(paste("fwd=", paste(forward_in, collapse=",") , "\n", 
+              "filt=", paste(forward_out, collapse=","), "\n",
+              "compress=", !opt$no_gzip, "\n",
+              "truncQ=", filt_params$truncQ, "\n",  
+              "truncLen=", filt_params$truncLen, "\n", 
+              "trimLef=", filt_params$trimLeft, "\n",  
+              "maxLen=", filt_params$maxLen, "\n", 
+              "minLen=", filt_params$minLen, "\n",  
+              "maxN=", filt_params$maxN, "\n", 
+              "minQ=", filt_params$minQ, "\n",
+              "maxEE=", filt_params$maxEE, "\n",
+              "rm.phix=", !opt$no_rm_phiX, "\n",
+              "multithread=", multithread_opt, "\n",
+              "n=", opt$num_reads, "\n",
+              "verbose=", opt$verbose, "\n\n", sep=""))
+  }
+  
+  read_counts <- filterAndTrim(fwd=forward_in, filt=forward_out, compress=!opt$no_gzip,
+                               truncQ=filt_params$truncQ, truncLen=filt_params$truncLen,
+                               trimLeft=filt_params$trimLeft, maxLen=filt_params$maxLen,
+                               minLen=filt_params$minLen, maxN=filt_params$maxN,
+                               minQ=filt_params$minQ, maxEE=filt_params$maxEE, 
+                               rm.phix=!opt$no_rm_phiX, multithread=multithread_opt,
+                               n=opt$num_reads, verbose=opt$verbose)
+
+} else {
+  
+  # Read in path to reverse FASTQs.
+  if(is.null(opt$r_path)) {
+    opt$r_path <- opt$f_path
+  }
+  
+  reverse_in <- sort(list.files(opt$r_path, pattern=opt$r_match, full.names=TRUE))
+  reverse_samples <- sapply(strsplit(basename(reverse_in), opt$sample_delim), `[`, 1)
+  reverse_out <- file.path(opt$output, paste0(reverse_samples, "_R2_filt.fastq.gz"))
+  
+  # Check that sample names for forward and reverse FASTQs are the same.
+  if(! identical(forward_samples, reverse_samples)){
+    stop(paste("Sample names parsed from forward and reverse filenames don't match.",
+               "\n\nForward sample names:", forward_samples,
+               "\n\nReverse sample names:", reverse_samples))
+  }
+  
+  if(opt$verbose) {
+    cat("Paired-end mode\n")
+    cat(paste("fwd=", paste(forward_in, collapse=",") , "\n", 
+              "filt=", paste(forward_out, collapse=","), "\n",
+              "rev=", paste(reverse_in, collapse=","), "\n",
+              "filt.rev=", paste(reverse_out, collapse=","), "\n",
+              "compress=", !opt$no_gzip, "\n",
+              "truncQ=", filt_params$truncQ, "\n",  
+              "truncLen=", filt_params$truncLen, "\n", 
+              "trimLef=", filt_params$trimLeft, "\n",  
+              "maxLen=", filt_params$maxLen, "\n", 
+              "minLen=", filt_params$minLen, "\n",  
+              "maxN=", filt_params$maxN, "\n", 
+              "minQ=", filt_params$minQ, "\n",
+              "maxEE=", filt_params$maxEE, "\n",
+              "rm.phix=", !opt$no_rm_phiX, "\n",
+              "multithread=", multithread_opt, "\n",
+              "n=", opt$num_reads, "\n",
+              "matchIDs=", opt$matchIDs, "\n", 
+              "id.sep=", opt$id_sep, "\n",
+              "id.field=", opt$id_field, "\n", 
+              "verbose=", opt$verbose, "\n\n", sep=""))
+  }
+  
+  read_counts <- filterAndTrim(fwd=forward_in, filt=forward_out, rev=reverse_in,
+                               filt.rev=reverse_out, compress=!opt$no_gzip,
+                               truncQ=filt_params$truncQ, truncLen=filt_params$truncLen,
+                               trimLeft=filt_params$trimLeft, maxLen=filt_params$maxLen,
+                               minLen=filt_params$minLen, maxN=filt_params$maxN,
+                               minQ=filt_params$minQ, maxEE=filt_params$maxEE, 
+                               rm.phix=!opt$no_rm_phiX, multithread=multithread_opt,
+                               n=opt$num_reads, matchIDs=opt$matchIDs, id.sep=opt$id_sep,
+                               id.field=opt$id_field, verbose=opt$verbose)
+  
+}
+
+# Convert log table rownames from R1 FASTQs to sample names.
+read_counts <- as.data.frame(read_counts)
+rownames(read_counts) <- sapply(strsplit(rownames(read_counts), opt$sample_delim), `[`, 1)
+colnames(read_counts) <- c("input", "filtered")
+
+# Print out input and output read counts to logfile.
+write.table(x = read_counts, file = opt$log, quote = FALSE, sep="\t",
+            col.names = NA, row.names = TRUE)

--- a/dada2_filter.R
+++ b/dada2_filter.R
@@ -88,7 +88,7 @@ option_list <- list(
               metavar = "boolean"),
   
   make_option(c("--id_sep"), type="character", default="\\s",
-              help="The separator between fields in the id line for paired-end FASTQs (default: \"\\s\").", 
+              help="The separator between fields in the id line for paired-end FASTQs (default is whitespace: \"\\s\").", 
               metavar = "character"),
   
   make_option(c("--id_field"), type="character", default=NULL,
@@ -105,20 +105,21 @@ option_list <- list(
 
 )
 
-opt_parser <- OptionParser(option_list=option_list, 
-                           usage = "%prog [options] -f PATH",
-                           
-                           description = paste("\nThis is a wrapper for DADA2 that is based on the authors\'", 
-                                               "filtering step in the big data tutorial available here:",
-                                               "https://benjjneb.github.io/dada2/bigdata.html.\n\nBe sure to cite the DADA2",
-                                               "paper if you use this script:\nCallahan BJ et al. 2016. DADA2:",
-                                               "High-resolution sample inference from Illumina amplicon data.",
-                                               "Nature Methods 13:581-583.\n\nNote this script was tested with",
-                                               "DADA2 v1.4.0\n\nUSAGE NOTE: when passing filtering parameters for paired-end", 
-                                               "reads if you pass one value it will be used for both forward and reverse reads.",
-                                               "\nIf you pass two values separated by a comma then these values will be for the forward",
-                                               "and reverse reads respectively.", sep=" ")
-                          )
+opt_parser <- OptionParser(
+              option_list=option_list, 
+              usage = "%prog [options] -f PATH",
+              description = paste(
+                       "\nThis is a wrapper for DADA2 that is based on the authors\'", 
+                       "filtering step in the big data tutorial available here:",
+                       "https://benjjneb.github.io/dada2/bigdata.html.\n\nBe sure to cite the DADA2",
+                       "paper if you use this script:\nCallahan BJ et al. 2016. DADA2:",
+                       "High-resolution sample inference from Illumina amplicon data.",
+                       "Nature Methods 13:581-583.\n\nNote this script was tested with",
+                       "DADA2 v1.4.0\n\nUSAGE NOTE: when passing filtering parameters for paired-end", 
+                       "reads if you pass one value it will be used for both forward and reverse reads.",
+                       "\nIf you pass two values separated by a comma then these values will be for the forward",
+                       "and reverse reads respectively.", sep=" ")
+                        )
 
 opt <- parse_args(opt_parser)
 
@@ -150,9 +151,29 @@ parse_dada2_filt_params <- function(in_param, single_end, param_name) {
   }
   
   if (length(in_param_split) == 1) {
-    return(as.numeric(in_param_split[1]))
+    result = tryCatch({
+      return(as.numeric(in_param_split[1]))
+    }, warning = function(w) {
+      stop("Warning!")
+    }, error = function(e) {
+      stop(paste("Error input parameter", 
+                 param_name, "of",
+                 in_param_split[1],
+                 "is not numeric.", sep=" "))
+    })
   } else {
-    return(c(as.numeric(in_param_split[1]), as.numeric(in_param_split[2])))
+    result = tryCatch({
+      return(c(as.numeric(in_param_split[1]), as.numeric(in_param_split[2])))
+    }, warning = function(w) {
+      stop("Warning!")
+    }, error = function(e) {
+      stop(paste("Error at least 1 input parameter for", 
+                 param_name, "of",
+                 in_param_split[1], "or",
+                 in_param_split[2],
+                 "is not numeric.", sep=" "))
+    })
+    
   }
 }
 
@@ -252,7 +273,8 @@ if (opt$single) {
   if(! identical(forward_samples, reverse_samples)){
     stop(paste("\n\nSample names parsed from forward and reverse filenames don't match.",
                "\nForward sample name:", forward_samples,
-               "\nReverse sample name:", reverse_samples))
+               "\nReverse sample name:", reverse_samples,
+               "\n\nUse the -s option if your reads are single-end.\n"))
   }
   
   if(opt$verbose) {

--- a/dada2_inference.R
+++ b/dada2_inference.R
@@ -308,15 +308,15 @@ if(opt$plot_errors) {
   
  if(opt$single){
    pdf("estimated_err.pdf", width=7, height=7)
-   plotErrors(err_forward, nominalQ=TRUE)
+   print(plotErrors(err_forward, nominalQ=TRUE))
    dev.off()
  } else{
    pdf("estimated_forward_err.pdf", width=7, height=7)
-   plotErrors(err_forward, nominalQ=TRUE) 
+   print(plotErrors(err_forward, nominalQ=TRUE))
    dev.off()
    
    pdf("estimated_reverse_err.pdf", width=7, height=7)
-   plotErrors(err_reverse, nominalQ=TRUE) 
+   print(plotErrors(err_reverse, nominalQ=TRUE)) 
    dev.off()
  }
 }

--- a/dada2_inference.R
+++ b/dada2_inference.R
@@ -1,0 +1,299 @@
+#!/usr/bin/env Rscript
+
+# Read in package to read in command-line options.
+library("optparse")
+
+version <- "1.0"
+
+option_list <- list(
+
+  make_option(c("-f", "--f_path"), type="character", default=NULL,
+              help="Location of forward reads (required)." , metavar="path"),
+  
+  make_option(c("--seed"), type="integer", default=NULL,
+              help="Random seed to make command reproducible (required).", metavar = "integer"),
+  
+  make_option(c("-r", "--r_path"), type="character", default=NULL,
+              help="Location of reverse reads (if applicable). Same as forward reads by default.",
+              metavar="path"),
+  
+  make_option(c("-s", "--single"), action = "store_true", type="logical", default=FALSE,
+              help="Flag to indicate that reads are single-end (default: FALSE).", metavar = "boolean"),
+
+  make_option(c("--f_match"), type="character", default="_R1_.*fastq.*",
+              help="Regular expression to match in forward reads' filenames (default: \"_R1_.*fastq.*\").", 
+              metavar="PATTERN"),
+  
+  make_option(c("--r_match"), type="character", default="_R2_.*fastq.*",
+              help="Regular expression to match in reverse reads' filenames (default: \"_R2_.*fastq.*\").",
+              metavar="PATTERN"),
+  
+  make_option(c("--sample_delim"), type="character", default="_",
+              help=paste("Character to split filenames on to determine sample name (default: \"_\").",
+              "Sample names are assumed to be field 1 after splitting.", sep=" "),
+              metavar="PATTERN"),
+  
+  make_option(c("-t", "--threads"), type="integer", default=1,
+              help="Number of threads to use (default: 1).", metavar="integer"),
+  
+  make_option(c("-o", "--output"), type="character", default="seqtab.rds",
+              help="Output RDS file for sequence table (default: seqtab.rds).", metavar="path"),
+  
+  make_option(c("-n", "--num_learn"), type="integer", default=1e6,
+              help=paste("Min. number of reads for error rate learning (default: 1e6).", 
+                         "Samples will be read in until this read count is reached or all",
+                         "samples are read in.", sep=" "), metavar="integer"),
+  
+  make_option(c("--num_derep"), type="integer", default=1e6,
+              help="Number of reads to read into memory when dereplicating (default: 1e6).", 
+                    metavar="integer"),
+  
+  make_option(c("--randomize"), action = "store_true", type="logical", default=FALSE,
+              help=paste("Flag to indicate that samples should be read in random order",
+                         "for learnErrors step (default: FALSE).", sep=" "),
+              metavar = "boolean"),
+  
+  make_option(c("--selfConsist"), action = "store_true", type="logical", default=FALSE,
+              help=paste("Flag to indicate that dada algorithm should alternate between sample",
+                         "inference and error rate estimate until convergence (default: FALSE).", 
+                         sep=" "), metavar = "boolean"),
+  
+  make_option(c("--pool"), action = "store_true", type="logical", default=FALSE,
+              help=paste("Flag to indicate that all samples should be pooled before sample",
+                         "inference step (default: FALSE).", sep=" "), metavar = "boolean"),
+  
+  make_option(c("--minOverlap"), type="integer", default=20,
+              help="Min length of overlap required for merging reads (default: 20).", 
+              metavar="integer"),
+  
+  make_option(c("--maxMismatch"), type="integer", default=0,
+              help="Max number of mismatches allowed in overlap when merging reads (default: 0).", 
+              metavar="integer"),
+  
+  make_option(c("--returnRejects"), action = "store_true", type="logical", default=FALSE,
+              help=paste("Flag to indicate that pairs that had more than the max number", 
+                         "of mismatches should be retained in the output dataframe",
+                         "(default: FALSE).", sep=" "), metavar = "boolean"),
+  
+  make_option(c("--justConcatenate"), action = "store_true", type="logical", default=FALSE,
+              help=paste("Flag to indicate that forward and reverse reads should just", 
+                               "be concatenated with 10 Ns as spacers between them",
+                               "(default: FALSE).", sep=" "), metavar = "boolean"),
+  
+  make_option(c("--trimOverhang"), action = "store_true", type="logical", default=FALSE,
+              help=paste("Flag to indicate that overhands in alignment between forward",
+                         "and reverse reads are trimmed off. This can happen when the reads",
+                         "are bigger than the amplicon (default: False).", sep=" "), 
+              metavar = "boolean"),
+  
+  make_option(c("--log"), type="character", default="dada2_inferred_read_counts.txt",
+              help="Output logfile for read count table (default: dada2_inferred_read_counts.txt).", 
+              metavar="path"),
+  
+  make_option(c("--verbose"), action = "store_true", type="logical", default=FALSE,
+              help="Write out status messages (default: FALSE).", metavar = "boolean"),
+  
+  make_option(c("--version"), action = "store_true", type="logical", default=FALSE,
+              help="Print out version number and exit.", metavar = "boolean")
+
+)
+
+opt_parser <- OptionParser(option_list=option_list, 
+                           usage = "%prog [options] -f PATH --seed 123",
+                           
+                           description = paste("\nThis is a wrapper for the DADA2 inference step that is", 
+                                               "based on the authors\' big data tutorial available here:",
+                                               "https://benjjneb.github.io/dada2/bigdata.html.\n\nBe sure to cite the DADA2",
+                                               "paper if you use this script:\nCallahan BJ et al. 2016. DADA2:",
+                                               "High-resolution sample inference from Illumina amplicon data.",
+                                               "Nature Methods 13:581-583.\n\nNote this script was tested with",
+                                               "DADA2 v1.4.0", sep=" ")
+                          )
+
+opt <- parse_args(opt_parser)
+
+# Print out version if --version flag set.
+if (opt$version) {
+  cat("Wrapper version:", version, "\n")
+  options_tmp <- options(show.error.messages=FALSE) 
+  on.exit(options(options_tmp)) 
+  stop()
+}
+
+# Check if path to forward files set, if not stop job.
+if(is.null(opt$f_path)) {
+  stop("path to forward FASTQs needs to be set.")
+}
+
+# Check that random seed set.
+if(is.null(opt$seed)) {
+  stop("random seed needs to be set.")
+}
+
+# Set multithread option (FALSE if no, otherwise give # core).
+if (opt$threads > 1) {
+  multithread_opt <- opt$threads
+} else {
+  multithread_opt <- FALSE
+}
+
+# Get forward filenames.
+forward_in <- sort(list.files(opt$f_path, pattern=opt$f_match, full.names=TRUE))
+forward_samples <- sapply(strsplit(basename(forward_in), opt$sample_delim), `[`, 1)
+names(forward_in) <- forward_samples
+
+# Read in and print out DADA2 version.
+library("dada2")
+
+if(opt$verbose) {
+  cat("Running DADA2 version:", as.character(packageVersion("dada2")), "\n")
+  cat("Random seed:", as.character(opt$seed), "\n")
+}
+
+# Set random seed for reproducibility.
+set.seed(opt$seed)
+
+  
+if(opt$verbose) {
+    cat("Running learnErrors with below options.\n")
+    cat(paste("fls=", paste(forward_in, collapse=",") , "\n",
+              "nreads=", opt$num_learn, "\n",
+              "multithread=", multithread_opt, "\n",
+              "randomize=", opt$randomize, "\n\n", sep=""))
+}
+
+# Learn error model for forward reads.
+err <- learnErrors(fls = forward_in, 
+                   nreads = opt$num_learn, 
+                   multithread = multithread_opt, 
+                   randomize=opt$randomize)
+
+# Initialize empty list with length of number of samples.
+seq_variants <- vector("list", length(forward_samples))
+names(seq_variants) <- forward_samples
+
+if(opt$verbose) {
+  cat("Will run derepFastq and dada with the below options.\n")
+  cat("derepFastq n =", opt$num_derep, "\n")
+  cat("dada selfConsist =", opt$selfConsist, "\n")
+  cat("dada pool =", opt$pool, "\n")
+  cat("dada multithread =", multithread_opt, "\n")
+}
+
+# Run dereplication and dada inference just on forward reads in single-end mode.
+if(opt$single) {
+  
+  if(opt$verbose) {
+    cat("Running dereplication and dada algorithm in single-end mode\n")
+  }
+  
+  # Initialize dataframe to keep track of read counts.
+  log_counts <- data.frame(matrix(NA, nrow=length(forward_samples), ncol=3))
+  rownames(log_counts) <- forward_samples
+  colnames(log_counts) <- c("sample", "derep_sum", "denoised")
+  
+  # Loop over all samples.
+  for(sample in forward_samples) {
+
+    if(opt$verbose) {
+      cat("Processing: ", sample, "\n")
+    }
+    
+    # Dereplicate reads.
+    derep_forward <- derepFastq(forward_in[[sample]], 
+                                n=opt$num_derep,
+                                verbose=opt$verbose)
+    
+    # Run inference and add inferred sequences to output list.
+    seq_variants[[sample]] <- dada(derep_forward, 
+                                   err=err, 
+                                   multithread=multithread_opt)
+    
+    # Add read counts to log dataframe for debug purposes.
+    log_counts[sample,] <- c(sample, sum(derep_forward$uniques), sum(seq_variants[[sample]]$denoised))
+
+  }
+
+# Learn errors for reverse too if paired.
+} else {
+  
+  # Initialize dataframe to keep track of read counts.
+  log_counts <- data.frame(matrix(NA, nrow=length(forward_samples), ncol=6))
+  rownames(log_counts) <- forward_samples
+  colnames(log_counts) <- c("sample", "forward_derep_sum", "reverse_derep_sum", 
+                            "forward_denoised", "reverse_denoised", "merged")
+  
+  # Read in path to reverse FASTQs.
+  if(is.null(opt$r_path)) {
+    opt$r_path <- opt$f_path
+  }
+  
+  # Read in reverse FASTQs
+  reverse_in <- sort(list.files(opt$r_path, pattern=opt$r_match, full.names=TRUE))
+  reverse_samples <- sapply(strsplit(basename(reverse_in), opt$sample_delim), `[`, 1)
+  names(reverse_in) <- reverse_samples
+  
+  # Check if forward and reverse sample names match.
+  if(! identical(forward_samples, reverse_samples)){
+    stop(paste("\n\nSample names parsed from forward and reverse filenames don't match.",
+               "\nForward sample name:", forward_samples,
+               "\nReverse sample name:", reverse_samples))
+  }
+  
+  if(opt$verbose) {
+    cat("Running learnErrors with below options for reverse reads.\n",
+        "fls =", paste(reverse_in, collapse=",") , "\n",
+        "nreads =", opt$num_learn, "\n",
+        "multithread =", multithread_opt, "\n",
+        "randomize =", opt$randomize, "\n\n",
+        "Running dereplication and dada algorithm in paired-end mode.\n\n",
+        "Will run mergePairs with below options.\n",
+        "minOverlap =", opt$minOverlap, "\n",
+        "maxMismatch =", opt$maxMismatch, "\n",
+        "returnRejects =", opt$returnRejects, "\n",
+        "justConcatenate =", opt$justConcatenate, "\n",
+        "trimOverhang =", opt$trimOverhang, "\n")
+  }
+  
+  # Loop over all samples.
+  for(sample in forward_samples) {
+    
+    if(opt$verbose) {
+      cat("Processing: ", sample, "\n")
+    }
+    
+    # Dereplicate reads.
+    derep_forward <- derepFastq(forward_in[[sample]], n=opt$num_derep, verbose=opt$verbose)
+    derep_reverse <- derepFastq(reverse_in[[sample]], n=opt$num_derep, verbose=opt$verbose)
+    
+    # Run inference and add inferred sequences to output list.
+    dada_out_forward <- dada(derep_forward, err=err, multithread=multithread_opt)
+    dada_out_reverse <- dada(derep_reverse, err=err, multithread=multithread_opt)
+    
+    # Merge forward and reverse reads together
+    seq_variants[[sample]] <- mergePairs(dadaF=dada_out_forward,
+                                         derepF=derep_forward,
+                                         dadaR=dada_out_reverse,
+                                         derepR=derep_reverse,
+                                         minOverlap=opt$minOverlap,
+                                         maxMismatch=opt$maxMismatch,
+                                         returnRejects=opt$returnRejects,
+                                         justConcatenate=opt$justConcatenate,
+                                         trimOverhang=opt$trimOverhang,
+                                         verbose=opt$verbose)
+    
+    # Add read counts to log dataframe for debug purposes.
+    log_counts[sample,] <- c(sample, sum(derep_forward$uniques), sum(derep_reverse$uniques), sum(dada_out_forward$denoised),
+                            sum(dada_out_reverse$denoised), sum(seq_variants[[sample]]$abundance))
+  }
+}
+
+# Write out sequence table as RDS.
+seqtab <- makeSequenceTable(seq_variants)
+saveRDS(seqtab, opt$output)
+
+# Write out logfile.
+log_counts$tabled <- rowSums(seqtab)
+
+write.table(x = log_counts, file = opt$log, quote = FALSE, sep="\t",
+            col.names = TRUE, row.names = FALSE)

--- a/merge_logfiles.R
+++ b/merge_logfiles.R
@@ -29,11 +29,12 @@ option_list <- list(
   
 )
 
-opt_parser <- OptionParser(option_list=option_list, 
-                           usage = "%prog [options] -i log1.txt,log2.txt",
-                           
-                           description = paste("Basic script to read in multiple logfiles and to merge them by rows.\n",
-                                               "The first column of each file is assumed to contain the sample names", sep="")
+opt_parser <- OptionParser(
+                     option_list=option_list,
+                     usage = "%prog [options] -i log1.txt,log2.txt",
+                     description = paste(
+                         "Basic script to read in multiple logfiles and to merge them by rows.\n",
+                         "The first column of each file is assumed to contain the sample names", sep="")
 )
 
 opt <- parse_args(opt_parser)

--- a/merge_logfiles.R
+++ b/merge_logfiles.R
@@ -1,0 +1,125 @@
+#!/usr/bin/env Rscript
+
+# Read in package to read in command-line options.
+library("optparse")
+
+version <- "1.0"
+
+option_list <- list(
+  
+  make_option(c("-i", "--input"), type="character", default=NULL,
+              help="Comma-delimited list of logfiles to combine (required)." , 
+              metavar="path"),
+  
+  make_option(c("-d", "--delim"), type="character", default="\t",
+              help="Character specifying how logfiles are delimited (default: \"\t\").", 
+              metavar="path"),
+  
+  make_option(c("-n", "--names"), type="character", default=NULL,
+              help=paste("Optional comma-delimited strings that should be added to distinguish",
+                         "the columns by file (default=NULL)."), 
+              metavar="path"),
+  
+  make_option(c("-o", "--output"), type="character", default="combined_log.txt",
+              help="Path to output file (default: \"combined_log.txt\").", 
+              metavar="path"),
+  
+  make_option(c("--version"), action = "store_true", type="logical", default=FALSE,
+              help="Print out version number and exit.", metavar = "boolean")
+  
+)
+
+opt_parser <- OptionParser(option_list=option_list, 
+                           usage = "%prog [options] -i log1.txt,log2.txt",
+                           
+                           description = paste("Basic script to read in multiple logfiles and to merge them by rows.\n",
+                                               "The first column of each file is assumed to contain the sample names", sep="")
+)
+
+opt <- parse_args(opt_parser)
+
+# Print out version if --version flag set.
+if (opt$version) {
+  cat("Wrapper version:", version, "\n")
+  options_tmp <- options(show.error.messages=FALSE) 
+  on.exit(options(options_tmp)) 
+  stop()
+}
+
+if(is.null(opt$input)) {
+  stop("paths to input logfiles need to be set.")
+}
+
+in_files <- strsplit(opt$input, ",")
+
+# Check if only one file given.
+if(length(in_files[[1]]) == 1) {
+  stop("only one input file given.") 
+}
+
+# Check if names option given and make sure same length as files if so.
+if(! is.null(opt$names)){
+  in_names <- strsplit(opt$names, ",")
+  
+  if(length(in_files[[1]]) != length(in_names[[1]])) {
+    stop("different numbers of infiles and names given.")
+  }
+}
+
+# Define function to add new empty rows and give them specified rownames in df.
+add_NA_rows <- function(rownames2add, df_in) {
+  
+  rows2add <- data.frame(matrix(NA, ncol=ncol(df_in), nrow=length(rownames2add)))
+  colnames(rows2add) <- colnames(df_in)
+  rownames(rows2add) <- rownames2add
+  
+  return(rbind(rows2add, df_in))
+  
+}
+
+# Define function to merge 2 dataframes on rownames. 
+# Will set any rows found in only 1 df to be all NAs in the df where it is missing.
+cbind_w_missing <- function(df1, df2) {
+ 
+   df1_only <- rownames(df1)[which(! rownames(df1) %in% rownames(df2))]
+   df2_only <- rownames(df2)[which(! rownames(df2) %in% rownames(df1))]
+  
+   if(length(df1_only >= 1)){
+     df2 <- add_NA_rows(df1_only, df2)
+   }
+   
+   if(length(df2_only >= 1)){
+     df1 <- add_NA_rows(df2_only, df1)
+   }
+   
+   return(cbind(df1, df2))
+   
+}
+
+# Keep file count marker.
+file_count = 0
+
+# Loop over index of all infiles.
+for(i in 1:length(in_files[[1]])){
+  infile <- read.table(in_files[[1]][i], header=TRUE, quote="", row.names=1, 
+                       sep=opt$delim, stringsAsFactors=FALSE)
+  
+  if (! is.null(opt$names)) {
+    colnames(infile) <- paste(in_names[[1]][i], colnames(infile), sep=".")
+  }
+  
+  file_count = file_count + 1
+  
+  if(file_count == 1) {
+    combined <- infile
+  } else {
+    combined <- cbind_w_missing(combined, infile)
+  }
+}
+
+all_col <- colnames(combined)
+combined$sample <- rownames(combined)
+combined <- combined[,c("sample", all_col)]
+
+write.table(x = combined, file = opt$output, quote = FALSE, sep = opt$delim,
+            col.names = TRUE, row.names = FALSE)

--- a/parse_cutadapt_logs.py
+++ b/parse_cutadapt_logs.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+__author__ = "Gavin Douglas"
+__credits__ = ["Gavin Douglas"]
+__license__ = "GPL"
+__version__ = "1.0"
+__maintainer__ = "Gavin Douglas"
+__email__ = "gavin.douglas@dal.ca"
+__status__ = "Development"
+
+import argparse
+import re
+import os
+
+parser = argparse.ArgumentParser(description="Parse cutadapt logfiles to \
+produce a table of read counts per sample.", epilog='''Usage example:
+
+parse_cutadapt_logs.py -i primer_trimmed_fastqs -m "_log.txt" \
+-o cutadapt_log.txt
+
+''', formatter_class=argparse.RawDescriptionHelpFormatter)
+
+parser.add_argument("-i", "--input", help="Folder containing cutadapt \
+logfiles", required=True, type=str)
+
+parser.add_argument("-m", "--match", help="String to match cutadapt log \
+filenames", required=False, default="_log.txt", type=str)
+
+parser.add_argument("-s", "--sample_delim", help="String to split filename on \
+to determine sample name (assumed to be 1st field after splitting",
+                    required=False, default="_", type=str)
+
+parser.add_argument("-o", "--output", help="Name of output read count table",
+                    required=False, default="cutadapt_log.txt", type=str)
+
+
+def main():
+
+    args = parser.parse_args()
+
+    # Check whether input folder exists.
+    if not os.path.isdir(args.input):
+        raise Exception("Input path " + args.input + " is not a directory")
+
+    # Read in cutadapt log filenames.
+    logfiles = [f for f in os.listdir(args.input) if args.match in f]
+
+    # Throw exception if no logfiles matched string.
+    if len(logfiles) == 0:
+        raise Exception("No logfiles found in folder " +
+                        args.input + " matching string " + args.match)
+
+    # Open output file for writing.
+    outfile = open(args.output, "w")
+
+    # Put samples in set to double-check they are all unique.
+    past_samples = set()
+
+    # Set flag for whether header printed or not.
+    header_printed = False
+
+    # Loop over all logfiles.
+    for logfile in logfiles:
+
+        sample = logfile.split(args.sample_delim)[0]
+
+        # Check whether sample already seen and if not add to set.
+        if sample in past_samples:
+            raise Exception("Parsed sample name " + sample +
+                            " is not unique!")
+
+        past_samples.add(sample)
+
+        log = args.input + "/" + logfile
+
+        # Initialize library object which will be either "single" or "paired"
+        library = None
+
+        # Initialize empty dict which will be actual counts parsed.
+        read_counts = {}
+
+        with open(log, "r") as infile:
+
+            for line in infile:
+
+                # Check if library defined. If not then check if library info
+                # is on line. If not then skip line. Set strings that should
+                # be matched as well depending on library type and what
+                # categories these strings correspond to.
+                if not library:
+                    if "in paired-end mode ..." in line:
+
+                        library = "paired"
+
+                        strings2match = ["Total read pairs processed:",
+                                         "Read 1 with adapter:",
+                                         "Read 2 with adapter:",
+                                         "Pairs written (passing filters):"]
+
+                        count_categories = ["pairs_in", "read1_match",
+                                            "read2_match", "pairs_passed"]
+
+                    elif "in single-end mode ..." in line:
+
+                        library = "single"
+
+                        strings2match = ["Total reads processed:",
+                                         "Reads with adapters:",
+                                         "Reads written (passing filters):"]
+
+                        count_categories = ["reads_in", "reads_match",
+                                            "reads_passed"]
+
+                    # Check if header printed yet and if not then do so.
+                    if library and not header_printed:
+                        header_out = ["Sample"] + count_categories
+                        print("\t".join(header_out), file=outfile)
+                        header_printed = True
+
+                    # Skip to next line.
+                    continue
+
+                # If library defined then check for matching strings.
+                for i in range(len(strings2match)):
+
+                    if strings2match[i] in line:
+
+                        count_regex = r".*" + re.escape(strings2match[i]) + \
+                                       "\s+" + "([0-9]+,*[0-9]*).*"
+
+                        count_match = re.match(count_regex, line).group(1)
+
+                        if(count_match):
+                            category_match = count_categories[i]
+
+                            # Check whether this string was matched already.
+                            if category_match in read_counts:
+                                raise Exception("Multiple matches to string " +
+                                                strings2match[i] + " in " +
+                                                log)
+
+                            # Remove comma.
+                            count_match = count_match.replace(",", "")
+
+                            read_counts[category_match] = count_match
+
+        # If library was not defined then throw error.
+        if not library:
+            raise Exception("Sequencing library type could not be " +
+                            "determined for file " + log)
+
+        # Initialize list to write out per sample.
+        out_counts = [sample]
+
+        # Loop over strings/categories indices again and make sure they are
+        # all present.
+        for i in range(len(strings2match)):
+
+            if count_categories[i] not in read_counts:
+                raise Exception("Could not find line matching " +
+                                strings2match[i] + " for count of " +
+                                count_categories[i] + " in " + log)
+
+            out_counts = out_counts + [read_counts[count_categories[i]]]
+
+        print("\t".join(out_counts), file=outfile)
+
+    outfile.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/parse_cutadapt_logs.py
+++ b/parse_cutadapt_logs.py
@@ -115,7 +115,7 @@ def main():
 
                     # Check if header printed yet and if not then do so.
                     if library and not header_printed:
-                        header_out = ["Sample"] + count_categories
+                        header_out = ["sample"] + count_categories
                         print("\t".join(header_out), file=outfile)
                         header_printed = True
 


### PR DESCRIPTION
Main scripts to be used for new 16S workflow based on dada2 (and their tutorial available [here](https://benjjneb.github.io/dada2/bigdata.html)).

The 6 added scripts are:

* ```parse_cutadapt_logs.py``` - used for combining cutadapt logfiles to create 1 count table (see below).
* ```dada2_filter.R``` - performs filtering steps of dada2 big data tutorial.
* ```dada2_inference.R``` - main dada2 algorithm, infers variants.
* ```dada2_chimera_taxa.R``` - performs dada2 denovo bimera checking and assigns taxonomy.
* ```merge_logfiles.R``` - merge any tables based on overlapping ids in the first column and the same delimited format (e.g. tab-delimited). Intended to be used to combine the logfiles produced by the 4 above scripts.
* ```convert_dada2_out.R``` - script to convert dada2 sequence table to BIOM and a fasta file. Can also optionally read in dada2 assigned taxonomies and output them in tab-delimited format to be added to a BIOM file with the ```biom add-metadata``` command.

### Relevant commands

cutadapt can be run in parallel with a command like the one below (after creating the ```primer_trimmed_fastqs``` folder). ```parse_cutadapt_logs.py``` is expecting output logfiles in ```primer_trimmed_fastqs``` in this case.

```
parallel --eta --link --jobs 60 --noswap \
  'cutadapt \
    --pair-filter any \
    --no-indels \
    --discard-untrimmed \
    -g CCTACGGGNGGCWGCAG \
    -G GACTACHVGGGTATCTAATCC \
    -o primer_trimmed_fastqs/{1/.}.gz \
    -p primer_trimmed_fastqs/{2/.}.gz \
    {1} {2} \
    > primer_trimmed_fastqs/{1/.}_cutadapt_log.txt' \
  ::: ../raw_fastqs/*_R1_*.fastq.gz ::: ../raw_fastqs/*_R2_*.fastq.gz
```

Once an output BIOM table is created with an observation metadata file they can be combined with the below command (this requires the latest version of biom-format: 2.1.6.

```
biom add-metadata -i seqtab.biom -o seqtab_tax.biom --observation-metadata-fp taxa_metadata.txt
```
